### PR TITLE
FIX NavigationTypeDefinition import and some eslint errors

### DIFF
--- a/NavigationAbstractPanResponder.js
+++ b/NavigationAbstractPanResponder.js
@@ -15,9 +15,9 @@ const PanResponder = require('react-native').PanResponder;
 
 const invariant = require('fbjs/lib/invariant');
 
-import type  {
+import type {
   NavigationPanPanHandlers,
-} from 'NavigationTypeDefinition';
+} from './NavigationTypeDefinition';
 
 const EmptyPanHandlers = {
   onMoveShouldSetPanResponder: null,

--- a/NavigationAnimatedValueSubscription.js
+++ b/NavigationAnimatedValueSubscription.js
@@ -27,9 +27,9 @@
  */
 'use strict';
 
-import type  {
-  NavigationAnimatedValue
-} from 'NavigationTypeDefinition';
+import type {
+  NavigationAnimatedValue,
+} from './NavigationTypeDefinition';
 
 class NavigationAnimatedValueSubscription {
   _value: NavigationAnimatedValue;

--- a/NavigationAnimatedView.js
+++ b/NavigationAnimatedView.js
@@ -27,7 +27,7 @@ import type {
   NavigationParentState,
   NavigationScene,
   NavigationSceneRenderer,
-} from 'NavigationTypeDefinition';
+} from './NavigationTypeDefinition';
 
 type Props = {
   applyAnimation: NavigationAnimationSetter,
@@ -44,7 +44,7 @@ type State = {
   scenes: Array<NavigationScene>,
 };
 
-const {PropTypes} = React;
+const { PropTypes } = React;
 
 function applyDefaultAnimation(
   position: NavigationAnimatedValue,

--- a/NavigationCard.js
+++ b/NavigationCard.js
@@ -45,13 +45,13 @@ const ReactComponentWithPureRenderMixin = require('react-addons-pure-render-mixi
 const StyleSheet = require('react-native').StyleSheet;
 const View = require('react-native').View;
 
-import type  {
+import type {
   NavigationPanPanHandlers,
   NavigationSceneRenderer,
   NavigationSceneRendererProps,
-} from 'NavigationTypeDefinition';
+} from './NavigationTypeDefinition';
 
-type SceneViewProps =  {
+type SceneViewProps = {
   sceneRenderer: NavigationSceneRenderer,
   sceneRendererProps: NavigationSceneRendererProps,
 };
@@ -64,7 +64,7 @@ type Props = NavigationSceneRendererProps & {
   style: any,
 };
 
-const {PropTypes} = React;
+const { PropTypes } = React;
 
 class SceneView extends React.Component<any, SceneViewProps, any> {
 

--- a/NavigationCardStack.js
+++ b/NavigationCardStack.js
@@ -44,18 +44,18 @@ const StyleSheet = require('react-native').StyleSheet;
 
 const emptyFunction = require('fbjs/lib/emptyFunction');
 
-const {PropTypes} = React;
-const {Directions} = NavigationCardStackPanResponder;
+const { PropTypes } = React;
+const { Directions } = NavigationCardStackPanResponder;
 
 import type {
   NavigationParentState,
   NavigationSceneRenderer,
   NavigationSceneRendererProps,
-} from 'NavigationTypeDefinition';
+} from './NavigationTypeDefinition';
 
 import type {
   NavigationGestureDirection,
-} from 'NavigationCardStackPanResponder';
+} from './NavigationCardStackPanResponder';
 
 type Props = {
   direction: NavigationGestureDirection,
@@ -140,7 +140,7 @@ class NavigationCardStack extends React.Component<DefaultProps, Props, void> {
     return (
       <NavigationCard
         {...props}
-        key={'card_' + props.scene.key}
+        key={`card_ ${props.scene.key}`}
         panHandlers={panHandlers}
         renderScene={this.props.renderScene}
         style={style}

--- a/NavigationCardStackPanResponder.js
+++ b/NavigationCardStackPanResponder.js
@@ -20,7 +20,7 @@ const clamp = require('clamp');
 import type {
   NavigationPanPanHandlers,
   NavigationSceneRendererProps,
-} from 'NavigationTypeDefinition';
+} from './NavigationTypeDefinition';
 
 /**
  * The duration of the card animation in milliseconds.
@@ -69,7 +69,7 @@ const Actions = {
   // The gesture to navigate backward.
   // This is done by swiping from the left to the right or from the top to the
   // bottom.
-  BACK: {type: 'back'},
+  BACK: { type: 'back' },
 };
 
 /**

--- a/NavigationCardStackStyleInterpolator.js
+++ b/NavigationCardStackStyleInterpolator.js
@@ -32,9 +32,9 @@
  */
 'use strict';
 
-import type  {
+import type {
   NavigationSceneRendererProps,
-} from 'NavigationTypeDefinition';
+} from './NavigationTypeDefinition';
 
 /**
  * Utility that builds the style for the card in the cards stack.

--- a/NavigationFindReducer.js
+++ b/NavigationFindReducer.js
@@ -19,8 +19,8 @@
 
 import type {
   NavigationState,
-  NavigationReducer
-} from 'NavigationTypeDefinition';
+  NavigationReducer,
+} from './NavigationTypeDefinition';
 
 function NavigationFindReducer(
   reducers: Array<NavigationReducer>,

--- a/NavigationHeader.js
+++ b/NavigationHeader.js
@@ -48,11 +48,11 @@ const {
   View,
 } = ReactNative;
 
-import type  {
+import type {
   NavigationSceneRenderer,
   NavigationSceneRendererProps,
   NavigationStyleInterpolator,
-} from 'NavigationTypeDefinition';
+} from './NavigationTypeDefinition';
 
 type DefaultProps = {
   renderLeftComponent: NavigationSceneRenderer,

--- a/NavigationHeaderBackButton.js
+++ b/NavigationHeaderBackButton.js
@@ -39,7 +39,7 @@ const NavigationHeaderBackButton = (props: Props) => (
 );
 
 NavigationHeaderBackButton.propTypes = {
-  onNavigate: React.PropTypes.func.isRequired
+  onNavigate: React.PropTypes.func.isRequired,
 };
 
 const styles = StyleSheet.create({
@@ -53,8 +53,8 @@ const styles = StyleSheet.create({
     height: 24,
     width: 24,
     margin: Platform.OS === 'ios' ? 10 : 16,
-    resizeMode: 'contain'
-  }
+    resizeMode: 'contain',
+  },
 });
 
 module.exports = NavigationContainer.create(NavigationHeaderBackButton);

--- a/NavigationHeaderStyleInterpolator.js
+++ b/NavigationHeaderStyleInterpolator.js
@@ -33,9 +33,9 @@
 'use strict';
 
 
-import type  {
+import type {
   NavigationSceneRendererProps,
-} from 'NavigationTypeDefinition';
+} from './NavigationTypeDefinition';
 
 /**
  * Utility that builds the style for the navigation header.
@@ -49,42 +49,42 @@ import type  {
  */
 
 function forLeft(props: NavigationSceneRendererProps): Object {
-  const {position, scene} = props;
-  const {index} = scene;
+  const { position, scene } = props;
+  const { index } = scene;
   return {
     opacity: position.interpolate({
-      inputRange: [ index - 1, index, index + 1 ],
-      outputRange: [ 0, 1, 0 ],
+      inputRange: [index - 1, index, index + 1],
+      outputRange: [0, 1, 0],
     }),
   };
 }
 
 function forCenter(props: NavigationSceneRendererProps): Object {
-  const {position, scene} = props;
-  const {index} = scene;
+  const { position, scene } = props;
+  const { index } = scene;
   return {
-    opacity:position.interpolate({
-      inputRange: [ index - 1, index, index + 1 ],
-      outputRange: [ 0, 1, 0 ],
+    opacity: position.interpolate({
+      inputRange: [index - 1, index, index + 1],
+      outputRange: [0, 1, 0],
     }),
     transform: [
       {
         translateX: position.interpolate({
-          inputRange: [ index - 1, index + 1 ],
-          outputRange: [ 200, -200 ],
+          inputRange: [index - 1, index + 1],
+          outputRange: [200, -200],
         }),
-      }
+      },
     ],
   };
 }
 
 function forRight(props: NavigationSceneRendererProps): Object {
-  const {position, scene} = props;
-  const {index} = scene;
+  const { position, scene } = props;
+  const { index } = scene;
   return {
     opacity: position.interpolate({
-      inputRange: [ index - 1, index, index + 1 ],
-      outputRange: [ 0, 1, 0 ],
+      inputRange: [index - 1, index, index + 1],
+      outputRange: [0, 1, 0],
     }),
   };
 }

--- a/NavigationHeaderTitle.js
+++ b/NavigationHeaderTitle.js
@@ -45,8 +45,8 @@ type Props = {
 }
 
 const NavigationHeaderTitle = ({ children, style, textStyle, viewProps }: Props) => (
-  <View style={[ styles.title, style ]} {...viewProps}>
-    <Text style={[ styles.titleText, textStyle ]}>{children}</Text>
+  <View style={[styles.title, style]} {...viewProps}>
+    <Text style={[styles.titleText, textStyle]}>{children}</Text>
   </View>
 );
 
@@ -55,7 +55,7 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
-    marginHorizontal: 16
+    marginHorizontal: 16,
   },
 
   titleText: {
@@ -63,14 +63,14 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: '500',
     color: 'rgba(0, 0, 0, .9)',
-    textAlign: Platform.OS === 'ios' ? 'center' : 'left'
-  }
+    textAlign: Platform.OS === 'ios' ? 'center' : 'left',
+  },
 });
 
 NavigationHeaderTitle.propTypes = {
   children: React.PropTypes.string.isRequired,
   style: View.propTypes.style,
-  textStyle: Text.propTypes.style
+  textStyle: Text.propTypes.style,
 };
 
 module.exports = NavigationHeaderTitle;

--- a/NavigationLegacyNavigator.js
+++ b/NavigationLegacyNavigator.js
@@ -37,7 +37,6 @@ const NavigationAnimatedValueSubscription = require('./NavigationAnimatedValueSu
 const NavigationAnimatedView = require('./NavigationAnimatedView');
 const NavigationCard = require('./NavigationCard');
 const NavigationCardStackStyleInterpolator = require('./NavigationCardStackStyleInterpolator');
-const NavigationContext = require('./NavigationContext');
 const NavigationLegacyNavigatorRouteStack = require('./NavigationLegacyNavigatorRouteStack');
 const NavigationCardStackPanResponder = require('./NavigationCardStackPanResponder');
 const NavigationPagerPanResponder = require('./NavigationPagerPanResponder');
@@ -45,17 +44,18 @@ const NavigationPagerStyleInterpolator = require('./NavigationPagerStyleInterpol
 const NavigatorBreadcrumbNavigationBar = require('./NavigatorBreadcrumbNavigationBar');
 const NavigatorNavigationBar = require('./NavigatorNavigationBar');
 const NavigatorSceneConfigs = require('./NavigatorSceneConfigs');
+const NavigationContext = require('./NavigationContext');
 const React = require('react');
 const ReactComponentWithPureRenderMixin = require('react-addons-pure-render-mixin');
 
-import type  {
+import type {
   NavigationActionCaller,
   NavigationAnimatedValue,
   NavigationAnimationSetter,
   NavigationParentState,
   NavigationSceneRenderer,
   NavigationSceneRendererProps,
-} from 'NavigationTypeDefinition';
+} from './NavigationTypeDefinition';
 
 type Props = {
   configureScene: any,
@@ -262,7 +262,7 @@ class NavigationLegacyNavigator extends React.Component<any, Props, State> {
       this._onPositionChange,
     );
 
-    const {navigationBar, navigationBarNavigator} = this.props;
+    const { navigationBar, navigationBarNavigator } = this.props;
     if (!navigationBar) {
       return null;
     }
@@ -279,12 +279,12 @@ class NavigationLegacyNavigator extends React.Component<any, Props, State> {
   }
 
   _renderCard(props: NavigationSceneRendererProps): ReactElement {
-    const {scene} = props;
-    const {configureScene} = this.props;
+    const { scene } = props;
+    const { configureScene } = this.props;
 
     // Default getters for style and pan responders.
     let styleGetter = NavigationCardStackStyleInterpolator.forHorizontal;
-    let panResponderGetter =  NavigationCardStackPanResponder.forHorizontal;
+    let panResponderGetter = NavigationCardStackPanResponder.forHorizontal;
 
     if (configureScene) {
       const route = RouteStack.getRouteByNavigationState(scene.navigationState);
@@ -326,7 +326,7 @@ class NavigationLegacyNavigator extends React.Component<any, Props, State> {
   }
 
   _renderScene(props: NavigationSceneRendererProps): ReactElement {
-    const {navigationState} = props.scene;
+    const { navigationState } = props.scene;
     const route = RouteStack.getRouteByNavigationState(navigationState);
     return this.props.renderScene(route, this);
   }
@@ -351,7 +351,7 @@ class NavigationLegacyNavigator extends React.Component<any, Props, State> {
 
   _onNavigationBarRef(navigationBarRef: any): void {
     this._navigationBarRef = navigationBarRef;
-    const {navigationBar} = this.props;
+    const { navigationBar } = this.props;
     if (navigationBar && typeof navigationBar.ref === 'function') {
       navigationBar.ref(navigationBarRef);
     }

--- a/NavigationLegacyNavigatorRouteStack.js
+++ b/NavigationLegacyNavigatorRouteStack.js
@@ -16,7 +16,7 @@ const invariant = require('fbjs/lib/invariant');
 import type {
   NavigationState,
   NavigationParentState,
-} from 'NavigationTypeDefinition';
+} from './NavigationTypeDefinition';
 
 type IterationCallback = (route: any, index: number, key: string) => void;
 

--- a/NavigationPagerPanResponder.js
+++ b/NavigationPagerPanResponder.js
@@ -21,12 +21,11 @@ const clamp = require('clamp');
 import type {
   NavigationPanPanHandlers,
   NavigationSceneRendererProps,
-} from 'NavigationTypeDefinition';
+} from './NavigationTypeDefinition';
 
 import type {
   NavigationGestureDirection,
-} from 'NavigationCardStackPanResponder';
-
+} from './NavigationCardStackPanResponder';
 
 
 /**
@@ -44,8 +43,8 @@ const {
  * Primitive gesture actions.
  */
 const Actions = {
-  JUMP_BACK: {type: 'jump_back'},
-  JUMP_FORWARD: {type: 'jump_forward'},
+  JUMP_BACK: { type: 'jump_back' },
+  JUMP_FORWARD: { type: 'jump_forward' },
 };
 
 /**

--- a/NavigationPagerStyleInterpolator.js
+++ b/NavigationPagerStyleInterpolator.js
@@ -32,9 +32,9 @@
  */
 'use strict';
 
-import type  {
+import type {
   NavigationSceneRendererProps,
-} from 'NavigationTypeDefinition';
+} from './NavigationTypeDefinition';
 
 /**
  * Utility that builds the style for the card in the cards list.
@@ -95,7 +95,7 @@ function forHorizontal(props: NavigationSceneRendererProps): Object {
   });
 
   return {
-    opacity : 1,
+    opacity: 1,
     shadowColor: 'transparent',
     shadowRadius: 0,
     transform: [

--- a/NavigationPointerEventsContainer.js
+++ b/NavigationPointerEventsContainer.js
@@ -37,9 +37,9 @@ const NavigationAnimatedValueSubscription = require('./NavigationAnimatedValueSu
 
 const invariant = require('fbjs/lib/invariant');
 
-import type  {
+import type {
   NavigationSceneRendererProps,
-} from 'NavigationTypeDefinition';
+} from './NavigationTypeDefinition';
 
 type Props = NavigationSceneRendererProps;
 
@@ -150,7 +150,7 @@ function create(
       return 'auto';
     }
   }
-  return  Container;
+  return Container;
 }
 
 module.exports = {

--- a/NavigationPropTypes.js
+++ b/NavigationPropTypes.js
@@ -11,9 +11,9 @@
  */
 'use strict';
 
-import type  {
+import type {
   NavigationSceneRendererProps,
-} from 'NavigationTypeDefinition';
+} from './NavigationTypeDefinition';
 
 /**
  * React component PropTypes Definitions. Consider using this as a supplementary
@@ -25,10 +25,10 @@ import type  {
 const Animated = require('react-native').Animated;
 const React = require('react');
 
-const {PropTypes} = React;
+const { PropTypes } = React;
 
 /* NavigationAction */
-const action =  PropTypes.shape({
+const action = PropTypes.shape({
   type: PropTypes.string.isRequired,
 });
 

--- a/NavigationReducer.js
+++ b/NavigationReducer.js
@@ -11,9 +11,9 @@
  */
 'use strict';
 
-var NavigationFindReducer = require('./NavigationFindReducer');
-var NavigationStackReducer = require('./NavigationStackReducer');
-var NavigationTabsReducer = require('./NavigationTabsReducer');
+const NavigationFindReducer = require('./NavigationFindReducer');
+const NavigationStackReducer = require('./NavigationStackReducer');
+const NavigationTabsReducer = require('./NavigationTabsReducer');
 
 const NavigationReducer = {
   FindReducer: NavigationFindReducer,

--- a/NavigationRootContainer.js
+++ b/NavigationRootContainer.js
@@ -23,7 +23,7 @@ import type {
   NavigationParentState,
   NavigationReducer,
   NavigationRenderer,
-} from 'NavigationTypeDefinition';
+} from './NavigationTypeDefinition';
 
 export type BackAction = {
   type: 'BackAction',
@@ -71,7 +71,7 @@ function getBackAction(): BackAction {
   return { type: 'BackAction' };
 }
 
-const {PropTypes} = React;
+const { PropTypes } = React;
 
 class NavigationRootContainer extends React.Component<any, Props, State> {
   _handleOpenURLEvent: Function;

--- a/NavigationScenesReducer.js
+++ b/NavigationScenesReducer.js
@@ -16,7 +16,7 @@ const invariant = require('fbjs/lib/invariant');
 import type {
   NavigationParentState,
   NavigationScene,
-} from 'NavigationTypeDefinition';
+} from './NavigationTypeDefinition';
 
 const SCENE_KEY_PREFIX = 'scene_';
 
@@ -24,7 +24,7 @@ const SCENE_KEY_PREFIX = 'scene_';
  * Helper function to compare route keys (e.g. "9", "11").
  */
 function compareKey(one: string, two: string): number {
-  var delta = one.length - two.length;
+  const delta = one.length - two.length;
   if (delta > 0) {
     return 1;
   }
@@ -79,7 +79,7 @@ function NavigationScenesReducer(
 
   // Populate stale scenes from previous scenes marked as stale.
   scenes.forEach(scene => {
-    const {key} = scene;
+    const { key } = scene;
     if (scene.isStale) {
       staleScenes.set(key, scene);
     }
@@ -129,7 +129,7 @@ function NavigationScenesReducer(
   const nextScenes = [];
 
   const mergeScene = (nextScene => {
-    const {key} = nextScene;
+    const { key } = nextScene;
     const prevScene = prevScenes.has(key) ? prevScenes.get(key) : null;
     if (prevScene && areScenesShallowEqual(prevScene, nextScene)) {
       // Reuse `prevScene` as `scene` so view can avoid unnecessary re-render.

--- a/NavigationStackReducer.js
+++ b/NavigationStackReducer.js
@@ -11,17 +11,17 @@
  */
 'use strict';
 
-var NavigationStateUtils = require('./NavigationStateUtils');
+const NavigationStateUtils = require('./NavigationStateUtils');
 
 import type {
   NavigationState,
   NavigationParentState,
   NavigationReducer,
-} from 'NavigationTypeDefinition';
+} from './NavigationTypeDefinition';
 
 import type {
   BackAction,
-} from 'NavigationRootContainer';
+} from './NavigationRootContainer';
 
 export type NavigationStackReducerAction = BackAction | {
   type: string,

--- a/NavigationStateUtils.js
+++ b/NavigationStateUtils.js
@@ -16,7 +16,7 @@ const invariant = require('fbjs/lib/invariant');
 import type {
   NavigationState,
   NavigationParentState,
-} from 'NavigationTypeDefinition';
+} from './NavigationTypeDefinition';
 
 function getParent(state: NavigationState): ?NavigationParentState {
   if (
@@ -53,7 +53,7 @@ function indexOf(state: NavigationState, key: string): ?number {
 }
 
 function push(state: NavigationParentState, newChildState: NavigationState): NavigationParentState {
-  var lastChildren: Array<NavigationState> = state.children;
+  const lastChildren: Array<NavigationState> = state.children;
   return {
     ...state,
     children: [

--- a/NavigationTabsReducer.js
+++ b/NavigationTabsReducer.js
@@ -17,7 +17,7 @@ const NavigationStateUtils = require('./NavigationStateUtils');
 import type {
   NavigationReducer,
   NavigationState,
-} from 'NavigationTypeDefinition';
+} from './NavigationTypeDefinition';
 
 const ActionTypes = {
   JUMP_TO: 'react-native/NavigationExperimental/tabs-jumpTo',

--- a/NavigationView.js
+++ b/NavigationView.js
@@ -27,7 +27,7 @@ import type {
   NavigationScene,
   NavigationSceneRenderer,
   NavigationSceneRendererProps,
-} from 'NavigationTypeDefinition';
+} from './NavigationTypeDefinition';
 
 type Props = {
   navigationState: NavigationParentState,
@@ -41,7 +41,7 @@ type State = {
   scenes: Array<NavigationScene>,
 };
 
-const {PropTypes} = React;
+const { PropTypes } = React;
 
 /**
  * A simple view that will render a scene for the currently focused sub-state.
@@ -71,7 +71,7 @@ class NavigationView extends React.Component<any, Props, any> {
       height: new Animated.Value(0),
     };
 
-    const {navigationState} = this.props;
+    const { navigationState } = this.props;
 
     this._position = new Animated.Value(navigationState.index);
 
@@ -91,7 +91,7 @@ class NavigationView extends React.Component<any, Props, any> {
 
   componentWillReceiveProps(nextProps: Props): void {
     if (nextProps.navigationState !== this.props.navigationState) {
-      const {navigationState} = nextProps;
+      const { navigationState } = nextProps;
       this.setState(
         {
           scenes: NavigationScenesReducer(
@@ -114,7 +114,7 @@ class NavigationView extends React.Component<any, Props, any> {
   render(): ReactElement {
     const {
       navigationState,
-      onNavigate
+      onNavigate,
     } = this.props;
 
     const {
@@ -150,7 +150,7 @@ class NavigationView extends React.Component<any, Props, any> {
   }
 
   _onLayout(event: any): void {
-    const {height, width} = event.nativeEvent.layout;
+    const { height, width } = event.nativeEvent.layout;
 
     const layout = {
       ...this.state.layout,


### PR DESCRIPTION
@aksonov 
In NavigationLegacyNavigator.js we have this imports =>

```
const NavigatorBreadcrumbNavigationBar = require('./NavigatorBreadcrumbNavigationBar');
const NavigatorNavigationBar = require('./NavigatorNavigationBar');
const NavigatorSceneConfigs = require('./NavigatorSceneConfigs');
const NavigationContext = require('./NavigationContext');
```
but there aren't the source files...it's a problem????