### PR TITLE
Usage of propTypes based on NODE_ENV

### DIFF
--- a/NavigationAnimatedView.js
+++ b/NavigationAnimatedView.js
@@ -69,13 +69,13 @@ class NavigationAnimatedView
   props: Props;
   state: State;
 
-  static propTypes = {
+  static propTypes = process.env.NODE_ENV !== 'production' ? {
     applyAnimation: PropTypes.func,
     navigationState: NavigationPropTypes.navigationState.isRequired,
     onNavigate: PropTypes.func.isRequired,
     renderOverlay: PropTypes.func,
     renderScene: PropTypes.func.isRequired,
-  };
+  } : {};
 
   static defaultProps = {
     applyAnimation: applyDefaultAnimation,

--- a/NavigationCard.js
+++ b/NavigationCard.js
@@ -68,10 +68,10 @@ const {PropTypes} = React;
 
 class SceneView extends React.Component<any, SceneViewProps, any> {
 
-  static propTypes = {
+  static propTypes = process.env.NODE_ENV !== 'production' ? {
     sceneRenderer: PropTypes.func.isRequired,
     sceneRendererProps: NavigationPropTypes.SceneRenderer,
-  };
+  } : {};
 
   shouldComponentUpdate(nextProps: SceneViewProps, nextState: any): boolean {
     return (
@@ -91,14 +91,14 @@ class SceneView extends React.Component<any, SceneViewProps, any> {
 class NavigationCard extends React.Component<any, Props, any> {
   props: Props;
 
-  static propTypes = {
+  static propTypes = process.env.NODE_ENV !== 'production' ? {
     ...NavigationPropTypes.SceneRendererProps,
     onComponentRef: PropTypes.func.isRequired,
     panHandlers: NavigationPropTypes.panHandlers,
     pointerEvents: PropTypes.string.isRequired,
     renderScene: PropTypes.func.isRequired,
     style: PropTypes.any,
-  };
+} : {};
 
   shouldComponentUpdate(nextProps: Props, nextState: any): boolean {
     return ReactComponentWithPureRenderMixin.shouldComponentUpdate.call(

--- a/NavigationCardStack.js
+++ b/NavigationCardStack.js
@@ -86,12 +86,12 @@ type DefaultProps = {
 class NavigationCardStack extends React.Component<DefaultProps, Props, void> {
   _renderScene : NavigationSceneRenderer;
 
-  static propTypes = {
+  static propTypes = process.env.NODE_ENV !== 'production' ? {
     direction: PropTypes.oneOf([Directions.HORIZONTAL, Directions.VERTICAL]),
     navigationState: NavigationPropTypes.navigationParentState.isRequired,
     renderOverlay: PropTypes.func,
     renderScene: PropTypes.func.isRequired,
-  };
+  } : {};
 
   static defaultProps: DefaultProps = {
     direction: Directions.HORIZONTAL,

--- a/NavigationHeader.js
+++ b/NavigationHeader.js
@@ -94,14 +94,14 @@ class NavigationHeader extends React.Component<DefaultProps, Props, any> {
     },
   };
 
-  static propTypes = {
+  static propTypes = process.env.NODE_ENV !== 'production' ? {
     ...NavigationPropTypes.SceneRendererProps,
     renderLeftComponent: PropTypes.func,
     renderRightComponent: PropTypes.func,
     renderTitleComponent: PropTypes.func,
     style: View.propTypes.style,
     viewProps: PropTypes.shape(View.propTypes),
-  };
+  } : {};
 
   shouldComponentUpdate(nextProps: Props, nextState: any): boolean {
     return ReactComponentWithPureRenderMixin.shouldComponentUpdate.call(

--- a/NavigationHeaderBackButton.js
+++ b/NavigationHeaderBackButton.js
@@ -38,9 +38,9 @@ const NavigationHeaderBackButton = (props: Props) => (
   </TouchableOpacity>
 );
 
-NavigationHeaderBackButton.propTypes = {
+NavigationHeaderBackButton.propTypes = process.env.NODE_ENV !== 'production' ? {
   onNavigate: React.PropTypes.func.isRequired
-};
+} : {};
 
 const styles = StyleSheet.create({
   buttonContainer: {

--- a/NavigationHeaderTitle.js
+++ b/NavigationHeaderTitle.js
@@ -67,10 +67,10 @@ const styles = StyleSheet.create({
   }
 });
 
-NavigationHeaderTitle.propTypes = {
+NavigationHeaderTitle.propTypes = process.env.NODE_ENV !== 'production' ? {
   children: React.PropTypes.string.isRequired,
   style: View.propTypes.style,
   textStyle: Text.propTypes.style
-};
+} : {};
 
 module.exports = NavigationHeaderTitle;

--- a/NavigationRootContainer.js
+++ b/NavigationRootContainer.js
@@ -79,13 +79,13 @@ class NavigationRootContainer extends React.Component<any, Props, State> {
   props: Props;
   state: State;
 
-  static propTypes = {
+  static propTypes = process.env.NODE_ENV !== 'production' ? {
     initialAction: NavigationPropTypes.action.isRequired,
     linkingActionMap: PropTypes.func,
     persistenceKey: PropTypes.string,
     reducer: PropTypes.func.isRequired,
     renderNavigation: PropTypes.func.isRequired,
-  };
+  } : {};
 
   static defaultProps = {
     initialAction: { type: 'RootContainerInitialAction' },

--- a/NavigationView.js
+++ b/NavigationView.js
@@ -54,11 +54,11 @@ class NavigationView extends React.Component<any, Props, any> {
   props: Props;
   state: State;
 
-  static propTypes = {
+  static propTypes = process.env.NODE_ENV !== 'production' ? {
     navigationState: PropTypes.object.isRequired,
     onNavigate: PropTypes.func.isRequired,
     renderScene: PropTypes.func.isRequired,
-  };
+  } : {};
 
   constructor(props: Props, context: any) {
     super(props, context);


### PR DESCRIPTION
For production builds(process.env.NODE_ENV=production) propTypes declaration could be skipped.