### PR TITLE
removed trailing comma

### DIFF
--- a/NavigationCard.js
+++ b/NavigationCard.js
@@ -105,7 +105,7 @@ class NavigationCard extends React.Component<any, Props, any> {
       pointerEvents,
       renderScene,
       style,
-      ...props, /* NavigationSceneRendererProps */
+      ...props /* NavigationSceneRendererProps */
     } = this.props;
 
     const viewStyle = style === undefined ?


### PR DESCRIPTION
There's a trailing comma error causing packager not to build with `babel` `v7` as I am trying to upgrade `react-native` to latest `0.56.0`. 

ps: I am using `react-native-router-flux` with `v3` because it is stable and I had few problems with `v4` 
you can see screenshot here https://github.com/facebook/react-native/issues/20273#issuecomment-405888286